### PR TITLE
Load BSAs on initialization. This is so that localization strings are…

### DIFF
--- a/frontend/msThreads.pas
+++ b/frontend/msThreads.pas
@@ -83,9 +83,6 @@ begin
     for i := 0 to Pred(slPlugins.Count) do
       Logger.Write('LOAD', 'Order', '['+IntToHex(i, 2)+'] '+slPlugins[i]);
 
-    Tracker.Write('Setting resource path');
-    wbContainerHandler.AddFolder(wbDataPath);
-
     // LOAD PLUGINS
     for i := 0 to Pred(slPlugins.Count) do begin
       Tracker.Write('Loading '+slPlugins[i]);
@@ -117,6 +114,9 @@ begin
       end;
     end;
 
+    // LOAD BSAS
+    Tracker.Write('Loading Resources');
+    wbContainerHandler.AddFolder(wbDataPath);
     LoadBSAs;
 
     // LOAD PLUGIN INFORMATION

--- a/frontend/msThreads.pas
+++ b/frontend/msThreads.pas
@@ -83,6 +83,9 @@ begin
     for i := 0 to Pred(slPlugins.Count) do
       Logger.Write('LOAD', 'Order', '['+IntToHex(i, 2)+'] '+slPlugins[i]);
 
+    Tracker.Write('Setting resource path');
+    wbContainerHandler.AddFolder(wbDataPath);
+
     // LOAD PLUGINS
     for i := 0 to Pred(slPlugins.Count) do begin
       Tracker.Write('Loading '+slPlugins[i]);
@@ -113,6 +116,8 @@ begin
         end;
       end;
     end;
+
+    LoadBSAs;
 
     // LOAD PLUGIN INFORMATION
     Tracker.Write('Loading plugin information');


### PR DESCRIPTION
… properly loaded. Otherwise some values will have error text instead of the real value, and Smash will think values are modified when they are not.

Note that I could have messed up formatting or variable naming compared to what you're used to. If you see anything you want renamed or reformatted let me know and I'll fix it.